### PR TITLE
Add cache, separate npm install and test

### DIFF
--- a/templates/javascript/nodejs-cross-platform-ci.yml
+++ b/templates/javascript/nodejs-cross-platform-ci.yml
@@ -15,9 +15,15 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: npm install and test
-      run: |
-        npm install
-        npm test
+    - name: Load npm cache
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - run: npm install
+      env:
+        CI: true
+    - run: npm test
       env:
         CI: true


### PR DESCRIPTION
Why hello! This is a cool repo 🎉 I've proposed some small changes:

- Added `actions/cache` to cache NPM stuff - speeds up multiple builds.
- Separated the `npm install` and `npm test` steps - doing this makes them show up better in the UI, with more clarity when one of them fails.

I had also change `npm install` to `npm ci` - I reverted it because its a change that has opinions™️ but I'm happy to add it back! Let me know if you have any questions about these changes 💪 